### PR TITLE
fix: forecasts が空のとき csv_path が未定義になるバグを修正

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -80,15 +80,16 @@ def save_data(forecasts):
         json.dump(forecasts, f, ensure_ascii=False, indent=4)
     
     # CSV 保存
+    csv_path = os.path.join("data", "all_forecasts.csv")
     if forecasts:
-        csv_path = os.path.join("data", "all_forecasts.csv")
         headers = ["date", "area_group", "prefecture", "location", "weather_code", "pop", "temp_min", "temp_max", "reliability"]
         with open(csv_path, "w", encoding="utf-8-sig", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=headers)
             writer.writeheader()
             writer.writerows(forecasts)
-    
-    print(f"\nSuccessfully saved {len(forecasts)} rows to {json_path} and {csv_path}")
+        print(f"\nSuccessfully saved {len(forecasts)} rows to {json_path} and {csv_path}")
+    else:
+        print(f"\nNo forecasts to save. JSON saved to {json_path}")
 
 if __name__ == "__main__":
     results = process_all_areas()


### PR DESCRIPTION
## Summary

- `csv_path` の定義を `if forecasts:` ブロックの外に移動し、`NameError` を解消
- `forecasts` が空の場合は CSV を保存せず、その旨をメッセージで通知するよう変更

## Related Issue

Closes #1

## Test plan

- [ ] `save_data([])` を呼び出しても `NameError` が発生しないことを確認
- [ ] `forecasts` に値がある場合は従来通り CSV・JSON が保存されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)