### PR TITLE
refactor: print を logging に置き換え、モジュールを分割

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,8 @@
+import logging
+
+
+def setup_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+    )

--- a/src/fetcher.py
+++ b/src/fetcher.py
@@ -1,0 +1,79 @@
+import logging
+import time
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+AREA_SETTINGS = [
+    {"area_code": "130000",  "office_code": "130000", "area_name": "首都圏", "prefecture": "東京", "location": "東京"},
+    {"area_code": "2710000", "office_code": "270000", "area_name": "近畿",   "prefecture": "大阪", "location": "大阪"},
+    {"area_code": "400000",  "office_code": "400000", "area_name": "九州",   "prefecture": "福岡", "location": "福岡"},
+    {"area_code": "370000",  "office_code": "370000", "area_name": "四国",   "prefecture": "香川", "location": "高松"},
+    {"area_code": "340000",  "office_code": "340000", "area_name": "中国",   "prefecture": "広島", "location": "広島"},
+    {"area_code": "2310000", "office_code": "230000", "area_name": "東海",   "prefecture": "愛知", "location": "名古屋"},
+    {"area_code": "0410001", "office_code": "040000", "area_name": "東北",   "prefecture": "宮城", "location": "仙台"},
+    {"area_code": "0110000", "office_code": "016000", "area_name": "北海道", "prefecture": "石狩", "location": "札幌"},
+    {"area_code": "0920100", "office_code": "090000", "area_name": "北関東", "prefecture": "栃木", "location": "宇都宮"},
+    {"area_code": "1720100", "office_code": "170000", "area_name": "北陸",   "prefecture": "石川", "location": "金沢"},
+]
+
+_JMA_FORECAST_URL = "https://www.jma.go.jp/bosai/forecast/data/forecast/{office_code}.json"
+_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+_REQUEST_TIMEOUT = 10
+_REQUEST_INTERVAL_SEC = 0.5
+# 気象庁APIのレスポンスは [0]=今日明日予報, [1]=週間予報 の構造
+_WEEKLY_FORECAST_INDEX = 1
+# エリアコードの前方5文字でtimeSeriesのareaとマッチングする
+_AREA_CODE_PREFIX_LEN = 5
+
+
+def _get_weekly_forecast_json(office_code: str) -> dict:
+    url = _JMA_FORECAST_URL.format(office_code=office_code)
+    headers = {"User-Agent": _USER_AGENT}
+    res = requests.get(url, headers=headers, timeout=_REQUEST_TIMEOUT)
+    res.raise_for_status()
+    return res.json()[_WEEKLY_FORECAST_INDEX]
+
+
+def process_all_areas() -> list[dict]:
+    all_forecasts = []
+
+    for setting in AREA_SETTINGS:
+        logger.info("Fetching: %s (%s)", setting["location"], setting["area_code"])
+        try:
+            weekly_data = _get_weekly_forecast_json(setting["office_code"])
+
+            ts0 = weekly_data["timeSeries"][0]
+            dates = ts0["timeDefines"]
+            prefix = setting["area_code"][:_AREA_CODE_PREFIX_LEN]
+
+            area0 = next((a for a in ts0["areas"] if prefix in a["area"]["code"]), ts0["areas"][0])
+            weather_codes = area0.get("weatherCodes", [])
+            pops = area0.get("pops", [])
+            reliabilities = area0.get("reliabilities", [])
+
+            ts1 = weekly_data["timeSeries"][1]
+            area1 = next((a for a in ts1["areas"] if prefix in a["area"]["code"]), ts1["areas"][0])
+            temps_min = area1.get("tempsMin", [])
+            temps_max = area1.get("tempsMax", [])
+
+            for i in range(len(dates)):
+                all_forecasts.append({
+                    "date": dates[i].split("T")[0],
+                    "area_group": setting["area_name"],
+                    "prefecture": setting["prefecture"],
+                    "location": setting["location"],
+                    "weather_code": weather_codes[i] if i < len(weather_codes) else "",
+                    "pop": pops[i] if i < len(pops) else "",
+                    "temp_min": temps_min[i] if i < len(temps_min) else "",
+                    "temp_max": temps_max[i] if i < len(temps_max) else "",
+                    "reliability": reliabilities[i] if i < len(reliabilities) else "",
+                })
+
+            time.sleep(_REQUEST_INTERVAL_SEC)
+
+        except Exception as e:
+            logger.error("Error fetching %s: %s", setting["location"], e)
+
+    return all_forecasts

--- a/src/main.py
+++ b/src/main.py
@@ -1,96 +1,13 @@
-import requests
-import json
-import csv
-import time
-import os
+from config import setup_logging
+from fetcher import process_all_areas
+from saver import save_data
 
-# ユーザー指定のエリア設定
-AREA_SETTINGS = [
-    {"area_code": "130000", "office_code": "130000", "area_name": "首都圏", "prefecture": "東京", "location": "東京"},
-    {"area_code": "2710000", "office_code": "270000", "area_name": "近畿", "prefecture": "大阪", "location": "大阪"},
-    {"area_code": "400000", "office_code": "400000", "area_name": "九州", "prefecture": "福岡", "location": "福岡"},
-    {"area_code": "370000", "office_code": "370000", "area_name": "四国", "prefecture": "香川", "location": "高松"},
-    {"area_code": "340000", "office_code": "340000", "area_name": "中国", "prefecture": "広島", "location": "広島"},
-    {"area_code": "2310000", "office_code": "230000", "area_name": "東海", "prefecture": "愛知", "location": "名古屋"},
-    {"area_code": "0410001", "office_code": "040000", "area_name": "東北", "prefecture": "宮城", "location": "仙台"},
-    {"area_code": "0110000", "office_code": "016000", "area_name": "北海道", "prefecture": "石狩", "location": "札幌"},
-    {"area_code": "0920100", "office_code": "090000", "area_name": "北関東", "prefecture": "栃木", "location": "宇都宮"},
-    {"area_code": "1720100", "office_code": "170000", "area_name": "北陸", "prefecture": "石川", "location": "金沢"},
-]
 
-def get_weekly_forecast_json(office_code):
-    url = f"https://www.jma.go.jp/bosai/forecast/data/forecast/{office_code}.json"
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-    }
-    res = requests.get(url, headers=headers, timeout=10)
-    res.raise_for_status()
-    return res.json()[1]
+def main() -> None:
+    setup_logging()
+    forecasts = process_all_areas()
+    save_data(forecasts)
 
-def process_all_areas():
-    all_forecasts = []
-    
-    for setting in AREA_SETTINGS:
-        print(f"Fetching: {setting['location']} ({setting['area_code']})...")
-        try:
-            weekly_data = get_weekly_forecast_json(setting["office_code"])
-            
-            ts0 = weekly_data["timeSeries"][0]
-            dates = ts0["timeDefines"]
-            target_area_code = setting["area_code"][:5]
-            
-            area0 = next((a for a in ts0["areas"] if target_area_code in a["area"]["code"]), ts0["areas"][0])
-            weather_codes = area0.get("weatherCodes", [])
-            pops = area0.get("pops", [])
-            reliabilities = area0.get("reliabilities", [])
-            
-            ts1 = weekly_data["timeSeries"][1]
-            area1 = next((a for a in ts1["areas"] if target_area_code in a["area"]["code"]), ts1["areas"][0])
-            temps_min = area1.get("tempsMin", [])
-            temps_max = area1.get("tempsMax", [])
-            
-            for i in range(len(dates)):
-                forecast = {
-                    "date": dates[i].split("T")[0],
-                    "area_group": setting["area_name"],
-                    "prefecture": setting["prefecture"],
-                    "location": setting["location"],
-                    "weather_code": weather_codes[i] if i < len(weather_codes) else "",
-                    "pop": pops[i] if i < len(pops) else "",
-                    "temp_min": temps_min[i] if i < len(temps_min) else "",
-                    "temp_max": temps_max[i] if i < len(temps_max) else "",
-                    "reliability": reliabilities[i] if i < len(reliabilities) else "",
-                }
-                all_forecasts.append(forecast)
-            
-            time.sleep(0.5)
-            
-        except Exception as e:
-            print(f"Error fetching {setting['location']}: {e}")
-            
-    return all_forecasts
-
-def save_data(forecasts):
-    # data/ ディレクトリの確認
-    os.makedirs("data", exist_ok=True)
-    
-    # JSON 保存
-    json_path = os.path.join("data", "all_forecasts.json")
-    with open(json_path, "w", encoding="utf-8") as f:
-        json.dump(forecasts, f, ensure_ascii=False, indent=4)
-    
-    # CSV 保存
-    csv_path = os.path.join("data", "all_forecasts.csv")
-    if forecasts:
-        headers = ["date", "area_group", "prefecture", "location", "weather_code", "pop", "temp_min", "temp_max", "reliability"]
-        with open(csv_path, "w", encoding="utf-8-sig", newline="") as f:
-            writer = csv.DictWriter(f, fieldnames=headers)
-            writer.writeheader()
-            writer.writerows(forecasts)
-        print(f"\nSuccessfully saved {len(forecasts)} rows to {json_path} and {csv_path}")
-    else:
-        print(f"\nNo forecasts to save. JSON saved to {json_path}")
 
 if __name__ == "__main__":
-    results = process_all_areas()
-    save_data(results)
+    main()

--- a/src/saver.py
+++ b/src/saver.py
@@ -1,0 +1,26 @@
+import csv
+import json
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_CSV_FIELDNAMES = ["date", "area_group", "prefecture", "location", "weather_code", "pop", "temp_min", "temp_max", "reliability"]
+
+
+def save_data(forecasts: list[dict]) -> None:
+    os.makedirs("data", exist_ok=True)
+
+    json_path = os.path.join("data", "all_forecasts.json")
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(forecasts, f, ensure_ascii=False, indent=4)
+
+    csv_path = os.path.join("data", "all_forecasts.csv")
+    if forecasts:
+        with open(csv_path, "w", encoding="utf-8-sig", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=_CSV_FIELDNAMES)
+            writer.writeheader()
+            writer.writerows(forecasts)
+        logger.info("Saved %d rows to %s and %s", len(forecasts), json_path, csv_path)
+    else:
+        logger.warning("No forecasts to save. JSON saved to %s", json_path)


### PR DESCRIPTION
## Summary

- `src/config.py` を新設し `setup_logging()` を定義（`jma-scraper-observed` と同じパターン）
- `src/fetcher.py` に API取得・パース処理を切り出し、`logger.info` / `logger.error` に置き換え
- `src/saver.py` に CSV/JSON保存処理を切り出し、`logger.info` / `logger.warning` に置き換え
- `src/main.py` をエントリーポイントのみに整理
- 各モジュールで `logging.getLogger(__name__)` を使用し、Cloud Logging で severity が正しく分類される

## Related Issue

Closes #3

## Test plan

- [ ] `uv run python src/main.py` を実行し、timestamp・level・モジュール名付きのログが出力されることを確認
- [ ] 全10地点のデータが取得され `data/` に保存されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)