### PR TITLE
refactor: エラーハンドリングを改善する

### DIFF
--- a/src/fetcher.py
+++ b/src/fetcher.py
@@ -38,9 +38,11 @@ def _get_weekly_forecast_json(office_code: str) -> dict:
 
 def process_all_areas() -> list[dict]:
     all_forecasts = []
+    skipped: list[str] = []
 
     for setting in AREA_SETTINGS:
-        logger.info("Fetching: %s (%s)", setting["location"], setting["area_code"])
+        location = setting["location"]
+        logger.info("Fetching: %s (%s)", location, setting["area_code"])
         try:
             weekly_data = _get_weekly_forecast_json(setting["office_code"])
 
@@ -63,7 +65,7 @@ def process_all_areas() -> list[dict]:
                     "date": dates[i].split("T")[0],
                     "area_group": setting["area_name"],
                     "prefecture": setting["prefecture"],
-                    "location": setting["location"],
+                    "location": location,
                     "weather_code": weather_codes[i] if i < len(weather_codes) else "",
                     "pop": pops[i] if i < len(pops) else "",
                     "temp_min": temps_min[i] if i < len(temps_min) else "",
@@ -73,7 +75,17 @@ def process_all_areas() -> list[dict]:
 
             time.sleep(_REQUEST_INTERVAL_SEC)
 
-        except Exception as e:
-            logger.error("Error fetching %s: %s", setting["location"], e)
+        except requests.exceptions.RequestException as e:
+            logger.error("Network error fetching %s: %s", location, e)
+            skipped.append(location)
+        except (KeyError, IndexError, ValueError) as e:
+            logger.error("Parse error fetching %s: %s", location, e)
+            skipped.append(location)
+
+    if skipped:
+        logger.warning("Skipped %d / %d areas: %s", len(skipped), len(AREA_SETTINGS), skipped)
+
+    if not all_forecasts:
+        raise RuntimeError("All areas failed. No forecast data was collected.")
 
     return all_forecasts

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,20 @@
+import logging
+import sys
+
 from config import setup_logging
 from fetcher import process_all_areas
 from saver import save_data
 
+logger = logging.getLogger(__name__)
+
 
 def main() -> None:
     setup_logging()
-    forecasts = process_all_areas()
+    try:
+        forecasts = process_all_areas()
+    except RuntimeError as e:
+        logger.error("%s", e)
+        sys.exit(1)
     save_data(forecasts)
 
 


### PR DESCRIPTION
## Summary

- `RequestException`（ネットワーク系）と `KeyError / IndexError / ValueError`（パース系）を分けて捕捉
- スキップしたエリアを集計し、処理完了時に件数・一覧をログ出力
- 全エリア失敗時は `RuntimeError` を raise し、`main.py` で `sys.exit(1)` して Cloud Run が異常終了を検知できるよう対応

## Related Issue

Closes #4

## Test plan

- [ ] 正常系: 全10地点が取得されログに `Saved 70 rows` が出ることを確認
- [ ] スキップ発生時: 一部エリアでエラーが起きた場合に `Skipped X / 10 areas` のログが出ることを確認
- [ ] 全件失敗時: exit code が非ゼロで終了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)