### PR TITLE
refactor: AREA_SETTINGS を locations.toml に切り出し config から読み込む

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,4 +1,10 @@
 import logging
+import tomllib
+from pathlib import Path
+
+from models import AreaSetting
+
+_LOCATIONS_TOML = Path(__file__).parent / "locations.toml"
 
 
 def setup_logging() -> None:
@@ -6,3 +12,9 @@ def setup_logging() -> None:
         level=logging.INFO,
         format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
     )
+
+
+def get_locations() -> list[AreaSetting]:
+    with _LOCATIONS_TOML.open("rb") as f:
+        data = tomllib.load(f)
+    return [AreaSetting.model_validate(item) for item in data["locations"]]

--- a/src/fetcher.py
+++ b/src/fetcher.py
@@ -8,19 +8,6 @@ from models import AreaSetting, Forecast
 
 logger = logging.getLogger(__name__)
 
-AREA_SETTINGS: list[AreaSetting] = [
-    AreaSetting(area_code="130000",  office_code="130000", area_name="首都圏", prefecture="東京", location="東京"),
-    AreaSetting(area_code="2710000", office_code="270000", area_name="近畿",   prefecture="大阪", location="大阪"),
-    AreaSetting(area_code="400000",  office_code="400000", area_name="九州",   prefecture="福岡", location="福岡"),
-    AreaSetting(area_code="370000",  office_code="370000", area_name="四国",   prefecture="香川", location="高松"),
-    AreaSetting(area_code="340000",  office_code="340000", area_name="中国",   prefecture="広島", location="広島"),
-    AreaSetting(area_code="2310000", office_code="230000", area_name="東海",   prefecture="愛知", location="名古屋"),
-    AreaSetting(area_code="0410001", office_code="040000", area_name="東北",   prefecture="宮城", location="仙台"),
-    AreaSetting(area_code="0110000", office_code="016000", area_name="北海道", prefecture="石狩", location="札幌"),
-    AreaSetting(area_code="0920100", office_code="090000", area_name="北関東", prefecture="栃木", location="宇都宮"),
-    AreaSetting(area_code="1720100", office_code="170000", area_name="北陸",   prefecture="石川", location="金沢"),
-]
-
 _JMA_FORECAST_URL = "https://www.jma.go.jp/bosai/forecast/data/forecast/{office_code}.json"
 _USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 _REQUEST_TIMEOUT = 10
@@ -42,11 +29,11 @@ def _get_weekly_forecast_json(office_code: str) -> dict[str, Any]:
     return res.json()[_WEEKLY_FORECAST_INDEX]  # type: ignore[no-any-return]
 
 
-def process_all_areas() -> list[Forecast]:
+def process_all_areas(locations: list[AreaSetting]) -> list[Forecast]:
     all_forecasts: list[Forecast] = []
     skipped: list[str] = []
 
-    for setting in AREA_SETTINGS:
+    for setting in locations:
         logger.info("Fetching: %s (%s)", setting.location, setting.area_code)
         try:
             weekly_data = _get_weekly_forecast_json(setting.office_code)
@@ -88,7 +75,7 @@ def process_all_areas() -> list[Forecast]:
             skipped.append(setting.location)
 
     if skipped:
-        logger.warning("Skipped %d / %d areas: %s", len(skipped), len(AREA_SETTINGS), skipped)
+        logger.warning("Skipped %d / %d areas: %s", len(skipped), len(locations), skipped)
 
     if not all_forecasts:
         raise RuntimeError("All areas failed. No forecast data was collected.")

--- a/src/locations.toml
+++ b/src/locations.toml
@@ -1,0 +1,69 @@
+[[locations]]
+area_name  = "首都圏"
+prefecture = "東京"
+location   = "東京"
+area_code  = "130000"
+office_code = "130000"
+
+[[locations]]
+area_name  = "近畿"
+prefecture = "大阪"
+location   = "大阪"
+area_code  = "2710000"
+office_code = "270000"
+
+[[locations]]
+area_name  = "九州"
+prefecture = "福岡"
+location   = "福岡"
+area_code  = "400000"
+office_code = "400000"
+
+[[locations]]
+area_name  = "四国"
+prefecture = "香川"
+location   = "高松"
+area_code  = "370000"
+office_code = "370000"
+
+[[locations]]
+area_name  = "中国"
+prefecture = "広島"
+location   = "広島"
+area_code  = "340000"
+office_code = "340000"
+
+[[locations]]
+area_name  = "東海"
+prefecture = "愛知"
+location   = "名古屋"
+area_code  = "2310000"
+office_code = "230000"
+
+[[locations]]
+area_name  = "東北"
+prefecture = "宮城"
+location   = "仙台"
+area_code  = "0410001"
+office_code = "040000"
+
+[[locations]]
+area_name  = "北海道"
+prefecture = "石狩"
+location   = "札幌"
+area_code  = "0110000"
+office_code = "016000"
+
+[[locations]]
+area_name  = "北関東"
+prefecture = "栃木"
+location   = "宇都宮"
+area_code  = "0920100"
+office_code = "090000"
+
+[[locations]]
+area_name  = "北陸"
+prefecture = "石川"
+location   = "金沢"
+area_code  = "1720100"
+office_code = "170000"

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 
-from config import setup_logging
+from config import get_locations, setup_logging
 from fetcher import process_all_areas
 from saver import save_data
 
@@ -10,8 +10,9 @@ logger = logging.getLogger(__name__)
 
 def main() -> None:
     setup_logging()
+    locations = get_locations()
     try:
-        forecasts = process_all_areas()
+        forecasts = process_all_areas(locations)
     except RuntimeError as e:
         logger.error("%s", e)
         sys.exit(1)


### PR DESCRIPTION
## Summary

- `src/locations.toml` を新設（`[[locations]]` 配列形式、`jma-scraper-observed` と同構成）
- `config.py` に `get_locations()` を追加（Python 3.11+ 標準の `tomllib` + `AreaSetting.model_validate()`）
- `fetcher.py` の `AREA_SETTINGS` 定数を削除し、`process_all_areas(locations: list[AreaSetting])` で外部から受け取る形に変更（テストしやすくなる）
- `main.py` で `get_locations()` を呼び出し `process_all_areas` に渡すよう更新
- `uv run mypy src/` がエラーゼロで通ることを確認済み

## Related Issue

Closes #8

## Test plan

- [ ] `uv run python src/main.py` で全10地点が正常に取得できることを確認
- [ ] `src/locations.toml` に地点を追加・削除してもコードを変更せずに反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)