### PR TITLE
docs: 各モジュール・関数に docstring を追加

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,3 +1,5 @@
+"""ロギング設定と地点設定の読み込みロジック。"""
+
 import logging
 import tomllib
 from pathlib import Path
@@ -8,6 +10,12 @@ _LOCATIONS_TOML = Path(__file__).parent / "locations.toml"
 
 
 def setup_logging() -> None:
+    """ロギングの初期設定を行う。
+
+    エントリポイント（main.py）から1回だけ呼び出す。
+    各モジュールは logging.getLogger(__name__) のみ使用し、
+    この関数は呼び出さない。
+    """
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
@@ -15,6 +23,16 @@ def setup_logging() -> None:
 
 
 def get_locations() -> list[AreaSetting]:
+    """locations.toml から予報エリアのリストを読み込んで返す。
+
+    Returns:
+        list[AreaSetting]: locations.toml に定義された予報エリアのリスト。
+
+    Raises:
+        FileNotFoundError: locations.toml が存在しない場合。
+        KeyError: locations.toml に "locations" キーが存在しない場合。
+        ValidationError: エントリが AreaSetting のスキーマに適合しない場合。
+    """
     with _LOCATIONS_TOML.open("rb") as f:
         data = tomllib.load(f)
     return [AreaSetting.model_validate(item) for item in data["locations"]]

--- a/src/fetcher.py
+++ b/src/fetcher.py
@@ -1,3 +1,5 @@
+"""気象庁 JSON API から週間予報データを取得・パースするモジュール。"""
+
 import logging
 import time
 from typing import Any
@@ -22,6 +24,17 @@ _AREA_CODE_PREFIX_LEN = 5
 
 
 def _get_weekly_forecast_json(office_code: str) -> dict[str, Any]:
+    """気象庁 API から指定オフィスの週間予報 JSON を取得する。
+
+    Args:
+        office_code: 気象庁の府県予報区コード。
+
+    Returns:
+        週間予報データの辞書（API レスポンスの index 1 に相当）。
+
+    Raises:
+        requests.exceptions.RequestException: ネットワークエラーまたは HTTP エラーが発生した場合。
+    """
     url = _JMA_FORECAST_URL.format(office_code=office_code)
     headers = {"User-Agent": _USER_AGENT}
     res = requests.get(url, headers=headers, timeout=_REQUEST_TIMEOUT)
@@ -30,6 +43,20 @@ def _get_weekly_forecast_json(office_code: str) -> dict[str, Any]:
 
 
 def process_all_areas(locations: list[AreaSetting]) -> list[Forecast]:
+    """指定された全エリアの週間予報を取得してフラットなレコードリストを返す。
+
+    各エリアで API 取得またはパースに失敗した場合はスキップしてログに記録する。
+    全エリアが失敗した場合は RuntimeError を送出する。
+
+    Args:
+        locations: 取得対象の予報エリアリスト。
+
+    Returns:
+        list[Forecast]: 全エリア・全日付のフラットな予報レコードリスト。
+
+    Raises:
+        RuntimeError: 全エリアで取得・パースに失敗し、データが1件も得られなかった場合。
+    """
     all_forecasts: list[Forecast] = []
     skipped: list[str] = []
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,5 @@
+"""気象庁週間予報取得ツールのエントリポイント。"""
+
 import logging
 import sys
 
@@ -9,6 +11,10 @@ logger = logging.getLogger(__name__)
 
 
 def main() -> None:
+    """ロギングを初期化し、予報データを取得して保存する。
+
+    全エリアの取得に失敗した場合は exit code 1 で終了する。
+    """
     setup_logging()
     locations = get_locations()
     try:

--- a/src/saver.py
+++ b/src/saver.py
@@ -1,3 +1,5 @@
+"""予報データを CSV および JSON ファイルに保存するモジュール。"""
+
 import csv
 import json
 import logging
@@ -11,6 +13,17 @@ _CSV_FIELDNAMES = ["date", "area_group", "prefecture", "location", "weather_code
 
 
 def save_data(forecasts: list[Forecast]) -> None:
+    """予報レコードリストを data/ ディレクトリに CSV および JSON で保存する。
+
+    forecasts が空の場合は JSON のみ保存し、CSV は生成しない。
+
+    Args:
+        forecasts: 保存対象の予報レコードリスト。
+
+    Side effects:
+        - data/all_forecasts.json を上書き保存する。
+        - forecasts が空でない場合、data/all_forecasts.csv を上書き保存する。
+    """
     os.makedirs("data", exist_ok=True)
 
     json_path = os.path.join("data", "all_forecasts.json")


### PR DESCRIPTION
## Summary

Google スタイルの docstring を全モジュール・全 public 関数に追加。

- `config.py`: モジュール docstring、`setup_logging()`、`get_locations()` に追加
- `fetcher.py`: モジュール docstring、`_get_weekly_forecast_json()`、`process_all_areas()` に追加（引数・戻り値・例外を記載）
- `saver.py`: モジュール docstring、`save_data()` に追加（副作用・空リスト時の挙動を記載）
- `main.py`: モジュール docstring、`main()` に追加

## Related Issue

Closes #12

## Test plan

- [ ] `uv run mypy src/` がエラーゼロで通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)