### PR TITLE
chore: テストを追加し CI を整備

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,5 +10,5 @@ jobs:
           python-version: '3.13'
       - run: pip install ruff pytest mypy types-requests pydantic
       - run: ruff check .
-      - run: mypy src/
-      - run: pytest
+      - run: mypy src/ tests/
+      - run: pytest tests/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
-      - run: pip install ruff pytest mypy types-requests pydantic
+      - run: pip install -e . ruff pytest mypy types-requests
       - run: ruff check .
       - run: mypy src/ tests/
       - run: pytest tests/ -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,12 @@ dependencies = [
 [dependency-groups]
 dev = [
     "mypy>=1.20.2",
+    "pytest>=8.0",
     "types-requests>=2.33.0.20260503",
 ]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
 
 [tool.mypy]
 python_version = "3.13"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,26 @@
+from config import get_locations
+from models import AreaSetting
+
+
+def test_get_locations_returns_area_settings() -> None:
+    locations = get_locations()
+
+    assert len(locations) > 0
+    assert all(isinstance(loc, AreaSetting) for loc in locations)
+
+
+def test_get_locations_has_required_fields() -> None:
+    locations = get_locations()
+
+    for loc in locations:
+        assert loc.area_code
+        assert loc.office_code
+        assert loc.area_name
+        assert loc.prefecture
+        assert loc.location
+
+
+def test_get_locations_default_count() -> None:
+    locations = get_locations()
+
+    assert len(locations) == 10

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,0 +1,90 @@
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from fetcher import process_all_areas
+from models import AreaSetting
+
+
+def _make_location(area_code: str = "130000", office_code: str = "130000", location: str = "東京") -> AreaSetting:
+    return AreaSetting(
+        area_code=area_code,
+        office_code=office_code,
+        area_name="首都圏",
+        prefecture="東京",
+        location=location,
+    )
+
+
+def _make_weekly_data(dates: list[str], area_code: str = "13000") -> dict:
+    return {
+        "timeSeries": [
+            {
+                "timeDefines": [f"{d}T00:00:00+09:00" for d in dates],
+                "areas": [{
+                    "area": {"code": area_code},
+                    "weatherCodes": ["100"] * len(dates),
+                    "pops":          ["10"]  * len(dates),
+                    "reliabilities": ["A"]   * len(dates),
+                }],
+            },
+            {
+                "timeDefines": [f"{d}T00:00:00+09:00" for d in dates],
+                "areas": [{
+                    "area": {"code": area_code},
+                    "tempsMin": ["15"] * len(dates),
+                    "tempsMax": ["22"] * len(dates),
+                }],
+            },
+        ]
+    }
+
+
+def test_process_all_areas_returns_correct_records() -> None:
+    dates = ["2026-05-04", "2026-05-05", "2026-05-06"]
+    mock_data = _make_weekly_data(dates)
+
+    with patch("fetcher._get_weekly_forecast_json", return_value=mock_data):
+        result = process_all_areas([_make_location()])
+
+    assert len(result) == 3
+    assert result[0]["date"] == "2026-05-04"
+    assert result[0]["location"] == "東京"
+    assert result[0]["weather_code"] == "100"
+    assert result[0]["pop"] == "10"
+    assert result[0]["temp_min"] == "15"
+    assert result[0]["temp_max"] == "22"
+    assert result[0]["reliability"] == "A"
+
+
+def test_process_all_areas_raises_when_all_fail() -> None:
+    with patch("fetcher._get_weekly_forecast_json", side_effect=requests.exceptions.ConnectionError("error")):
+        with pytest.raises(RuntimeError, match="All areas failed"):
+            process_all_areas([_make_location()])
+
+
+def test_process_all_areas_raises_on_parse_error() -> None:
+    with patch("fetcher._get_weekly_forecast_json", return_value={"timeSeries": []}):
+        with pytest.raises(RuntimeError, match="All areas failed"):
+            process_all_areas([_make_location()])
+
+
+def test_process_all_areas_partial_skip() -> None:
+    locations = [
+        _make_location(area_code="130000", office_code="130000", location="東京"),
+        _make_location(area_code="270000", office_code="270000", location="大阪"),
+    ]
+    dates = ["2026-05-04", "2026-05-05"]
+    mock_data = _make_weekly_data(dates)
+
+    def side_effect(office_code: str) -> dict:
+        if office_code == "130000":
+            return mock_data
+        raise requests.exceptions.ConnectionError("network error")
+
+    with patch("fetcher._get_weekly_forecast_json", side_effect=side_effect):
+        result = process_all_areas(locations)
+
+    assert len(result) == 2
+    assert all(r["location"] == "東京" for r in result)

--- a/tests/test_saver.py
+++ b/tests/test_saver.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from models import Forecast
+from saver import save_data
+
+
+def _make_forecast(date: str = "2026-05-04", location: str = "東京") -> Forecast:
+    return Forecast(
+        date=date,
+        area_group="首都圏",
+        prefecture="東京",
+        location=location,
+        weather_code="100",
+        pop="10",
+        temp_min="15",
+        temp_max="22",
+        reliability="A",
+    )
+
+
+def test_save_data_creates_json_and_csv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    save_data([_make_forecast("2026-05-04"), _make_forecast("2026-05-05")])
+
+    assert (tmp_path / "data" / "all_forecasts.json").exists()
+    assert (tmp_path / "data" / "all_forecasts.csv").exists()
+
+
+def test_save_data_json_content(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    save_data([_make_forecast("2026-05-04")])
+
+    data = json.loads((tmp_path / "data" / "all_forecasts.json").read_text(encoding="utf-8"))
+    assert len(data) == 1
+    assert data[0]["date"] == "2026-05-04"
+    assert data[0]["location"] == "東京"
+
+
+def test_save_data_empty_forecasts_no_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    save_data([])  # Issue #1 のバグ修正確認: NameError が出ないこと
+
+    assert (tmp_path / "data" / "all_forecasts.json").exists()
+    assert not (tmp_path / "data" / "all_forecasts.csv").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -82,12 +82,30 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -102,6 +120,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "pytest" },
     { name = "types-requests" },
 ]
 
@@ -114,6 +133,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.20.2" },
+    { name = "pytest", specifier = ">=8.0" },
     { name = "types-requests", specifier = ">=2.33.0.20260503" },
 ]
 
@@ -210,12 +230,30 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -287,6 +325,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/15/3228774cb7cd45f5f721ddf1b2242747f4eb834d0c491f0c02d606f09fed/pydantic_core-2.46.3-cp314-cp314t-win32.whl", hash = "sha256:ffe0883b56cfc05798bf994164d2b2ff03efe2d22022a2bb080f3b626176dd56", size = 1949756, upload-time = "2026-04-20T14:41:25.717Z" },
     { url = "https://files.pythonhosted.org/packages/b8/2a/c79cf53fd91e5a87e30d481809f52f9a60dd221e39de66455cf04deaad37/pydantic_core-2.46.3-cp314-cp314t-win_amd64.whl", hash = "sha256:706d9d0ce9cf4593d07270d8e9f53b161f90c57d315aeec4fb4fd7a8b10240d8", size = 2051305, upload-time = "2026-04-20T14:43:18.627Z" },
     { url = "https://files.pythonhosted.org/packages/0b/db/d8182a7f1d9343a032265aae186eb063fe26ca4c40f256b21e8da4498e89/pydantic_core-2.46.3-cp314-cp314t-win_arm64.whl", hash = "sha256:77706aeb41df6a76568434701e0917da10692da28cb69d5fb6919ce5fdb07374", size = 2026310, upload-time = "2026-04-20T14:41:01.778Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `tests/test_fetcher.py`（4件）
  - 正常系: 日付・地点・天気コード等が正しくパースされること
  - 全件ネットワークエラー → `RuntimeError` が発生すること
  - 全件パースエラー → `RuntimeError` が発生すること
  - 部分スキップ: 一部エラー時は残りのデータが返ること
- `tests/test_saver.py`（3件）
  - JSON・CSV が `data/` に生成されること
  - JSON の内容が正しいこと
  - 空リスト時に `NameError` が出ないこと（Issue #1 の修正確認）
- `tests/test_config.py`（3件）
  - `get_locations()` が `AreaSetting` のリストを返すこと
  - 全エントリに必須フィールドが揃っていること
  - デフォルト10地点が読み込まれること
- `pyproject.toml`: `pytest` を dev 依存に追加、`pythonpath = ["src"]` を設定
- `ci.yml`: `mypy src/ tests/` / `pytest tests/ -v` に更新

## Related Issue

Closes #7

## Test plan

- [ ] CI の lint-and-test ジョブが全ステップグリーンになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)