### PR TITLE
refactor: saver.py の os モジュールを pathlib.Path に統一

### DIFF
--- a/src/saver.py
+++ b/src/saver.py
@@ -3,12 +3,13 @@
 import csv
 import json
 import logging
-import os
+from pathlib import Path
 
 from models import Forecast
 
 logger = logging.getLogger(__name__)
 
+_DATA_DIR = Path("data")
 _CSV_FIELDNAMES = ["date", "area_group", "prefecture", "location", "weather_code", "pop", "temp_min", "temp_max", "reliability"]
 
 
@@ -24,15 +25,17 @@ def save_data(forecasts: list[Forecast]) -> None:
         - data/all_forecasts.json を上書き保存する。
         - forecasts が空でない場合、data/all_forecasts.csv を上書き保存する。
     """
-    os.makedirs("data", exist_ok=True)
+    _DATA_DIR.mkdir(exist_ok=True)
 
-    json_path = os.path.join("data", "all_forecasts.json")
-    with open(json_path, "w", encoding="utf-8") as f:
-        json.dump(forecasts, f, ensure_ascii=False, indent=4)
+    json_path = _DATA_DIR / "all_forecasts.json"
+    json_path.write_text(
+        json.dumps(forecasts, ensure_ascii=False, indent=4),
+        encoding="utf-8",
+    )
 
-    csv_path = os.path.join("data", "all_forecasts.csv")
+    csv_path = _DATA_DIR / "all_forecasts.csv"
     if forecasts:
-        with open(csv_path, "w", encoding="utf-8-sig", newline="") as f:
+        with csv_path.open("w", encoding="utf-8-sig", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=_CSV_FIELDNAMES)
             writer.writeheader()
             writer.writerows(forecasts)


### PR DESCRIPTION
## Summary

- `import os` を削除し `from pathlib import Path` に置き換え
- `os.makedirs("data", exist_ok=True)` → `_DATA_DIR.mkdir(exist_ok=True)`
- `os.path.join(...)` → `_DATA_DIR / "all_forecasts.json"` / `_DATA_DIR / "all_forecasts.csv"`
- `open(json_path, "w", ...)` + `json.dump(...)` → `json_path.write_text(...)`
- `open(csv_path, "w", ...)` → `csv_path.open("w", ...)`
- 出力先パスを `_DATA_DIR` 定数にまとめ、他モジュールとのスタイルを統一

## Related Issue

Closes #21

## Test plan

- [ ] `pytest tests/ -v` が 10 / 10 パスすることを確認
- [ ] `mypy src/ tests/` がエラーゼロで通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)