### PR TITLE
feat: Dockerfile を追加して Cloud Run にデプロイできるようにする

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# 開発ツール
+.venv/
+.vscode/
+.git/
+.github/
+
+# キャッシュ
+.pytest_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+*.pyo
+
+# プロジェクト設定・ドキュメント
+CLAUDE.md
+README.md
+.mise.toml
+.python-version
+.gitignore
+
+# テスト・開発用ファイル
+tests/
+
+# データ
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.13-slim
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev
+
+COPY src/ ./src/
+
+ENV PYTHONPATH=/app/src
+
+CMD ["uv", "run", "python", "src/main.py"]


### PR DESCRIPTION
## Summary

- `python:3.13-slim` ベースの Dockerfile を追加し、uv でパッケージをインストールするマルチステップ構成を採用
- `.dockerignore` を追加して、不要なファイル（`.venv/`、`tests/`、`data/` 等）をイメージに含めないよう設定
- jma-scraper-observed の Dockerfile パターンを踏襲し、プロジェクト間で一貫した構成を維持

## Related Issue

Closes #25

## Test plan

- [ ] `docker build -t jma-api-forecast .` でビルドが成功すること
- [ ] `docker run --rm jma-api-forecast` で予報データが取得・保存されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)